### PR TITLE
chore: clone only the last 5 commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ node_js:
   - 10
   - 8
   - 6
+git:
+  depth: 5


### PR DESCRIPTION
Per default the last 50 commits (depth=50) are cloned.
5 should be sufficient and much faster.