### PR TITLE
fix: allow passing a GitHub profile URL as a username

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,5 +1,5 @@
 import React, { useRef, useState, useEffect } from "react";
-import { download, uploadToTwitter, fetchData, downloadJSON } from "../utils/export";
+import { download, uploadToTwitter, fetchData, downloadJSON, cleanUsername } from "../utils/export";
 import ThemeSelector from "../components/themes";
 
 const App = () => {
@@ -21,6 +21,7 @@ const App = () => {
   const handleSubmit = e => {
     e.preventDefault();
 
+    setUsername(cleanUsername(username));
     setLoading(true);
     setError(null);
     setData(null);

--- a/src/utils/export.js
+++ b/src/utils/export.js
@@ -53,3 +53,7 @@ export async function uploadToTwitter(canvas) {
     console.error(err);
   }
 }
+
+export function cleanUsername(username){
+  return username.replace(/^(http|https):\/\/(?!www\.)github\.com\//, '');
+}


### PR DESCRIPTION
This PR allows passing a full URL in the username field  (e.g. `https://github.com/MyUsername`) and internally converts it to `MyUsername`.

