### PR TITLE
fix: allow full-url to work on the first attempt

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -26,7 +26,7 @@ const App = () => {
     setError(null);
     setData(null);
 
-    fetchData(username)
+    fetchData(cleanUsername(username))
       .then(data => {
         setLoading(false);
 
@@ -42,10 +42,6 @@ const App = () => {
         setLoading(false);
         setError("I could not check your profile successfully...");
       });
-  };
-
-  const handleChangeTheme = themeName => {
-    setTheme(themeName);
   };
 
   const onDownload = e => {


### PR DESCRIPTION
In #97 we allowed full GitHub URLs to be passed, but it did not work on the first attempt, people needed to click twice on the submit button for it to work.

I also found an unused function and removed it.