### PR TITLE
Read count from element text instead of missing data attr

### DIFF
--- a/src/utils/api/fetch.js
+++ b/src/utils/api/fetch.js
@@ -54,7 +54,7 @@ async function fetchDataForYear(url, year, format) {
         const color = COLOR_MAP[$day.attr("data-level")];
         const value = {
           date: $day.attr("data-date"),
-          count: parseInt($day.attr("data-count"), 10),
+          count: parseInt($day.text().split(" ")[0], 10) || 0,
           color,
           intensity: $day.attr("data-level") || 0
         };


### PR DESCRIPTION
Fixes #127.

Looks like GH removed the `data-count` attribute. This PR makes it so that we pass the count from the element text instead of the non-existent data attr.