### PR TITLE
add Requirements in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ The API for this project lives in the `src/pages/api` directory since GitHub doe
 
 The drawing mechanism lives in [the sallar/github-contributions-canvas repository](https://github.com/sallar/github-contributions-canvas).
 
+## Requirements
+
+- A valid github account.
+- Open activity in setting (`Settings` > `Public profile` > `Contributions & Activity`).
+  - [ ] Make profile private and hide activity
+
 ## Install
 
 Install the packages using [NPM](https://nodejs.org/en/):


### PR DESCRIPTION
If enable `Make profile private and hide activity`, everything will go bad

`Could not find your profile`.

It took me 20 minutes to debug this issue, so add this requirements in readme, hope it can help others

